### PR TITLE
MODLR-4266: STOP; SAML TIME!

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # goxmldsig
 
-[![Build Status](https://travis-ci.org/russellhaering/goxmldsig.svg?branch=master)](https://travis-ci.org/russellhaering/goxmldsig)
-[![GoDoc](https://godoc.org/github.com/russellhaering/goxmldsig?status.svg)](https://godoc.org/github.com/russellhaering/goxmldsig)
+[![Build Status](https://travis-ci.org/AtScaleInc/goxmldsig.svg?branch=master)](https://travis-ci.org/AtScaleInc/goxmldsig)
+[![GoDoc](https://godoc.org/github.com/AtScaleInc/goxmldsig?status.svg)](https://godoc.org/github.com/AtScaleInc/goxmldsig)
 
 XML Digital Signatures implemented in pure Go.
 
@@ -10,7 +10,7 @@ XML Digital Signatures implemented in pure Go.
 Install `goxmldsig` into your `$GOPATH` using `go get`:
 
 ```
-$ go get github.com/russellhaering/goxmldsig
+$ go get github.com/AtScaleInc/goxmldsig
 ```
 
 ## Usage
@@ -22,7 +22,7 @@ package main
 
 import (
     "github.com/beevik/etree"
-    "github.com/russellhaering/goxmldsig"
+    "github.com/AtScaleInc/goxmldsig"
 )
 
 func main() {
@@ -84,7 +84,7 @@ func validate(root *x509.Certificate, el *etree.Element) {
 
 ## Limitations
 
-This library was created in order to [implement SAML 2.0](https://github.com/russellhaering/gosaml2)
+This library was created in order to [implement SAML 2.0](https://github.com/AtScaleInc/gosaml2)
 without needing to execute a command line tool to create and validate signatures. It currently
 only implements the subset of relevant standards needed to support that implementation, but
 I hope to make it more complete over time. Contributions are welcome.

--- a/canonicalize.go
+++ b/canonicalize.go
@@ -4,7 +4,7 @@ import (
 	"sort"
 
 	"github.com/beevik/etree"
-	"github.com/russellhaering/goxmldsig/etreeutils"
+	"github.com/AtScaleInc/goxmldsig/etreeutils"
 )
 
 // Canonicalizer is an implementation of a canonicalization algorithm.

--- a/keystore.go
+++ b/keystore.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
-	"fmt"
 	"math/big"
 	"time"
 )
@@ -47,7 +46,6 @@ func NewMemoryX509KeyStore(privKey *rsa.PrivateKey, cert []byte) *MemoryX509KeyS
 }
 
 func RandomKeyStoreForTest() X509KeyStore {
-	fmt.Printf("generating new key store")
 	key, err := rsa.GenerateKey(rand.Reader, 1024)
 	if err != nil {
 		panic(err)
@@ -65,8 +63,6 @@ func RandomKeyStoreForTest() X509KeyStore {
 		SerialNumber:       "customserialnumber",
 		CommonName:         "commonName",
 	}
-	fmt.Printf("\n\n pay attention! \n\nHere is the raw issuer value prior to creating cert: %v", pkixName)
-	fmt.Printf("\n\n pay attention! \n\nHere is the somewhat formatted issuer value prior to creating cert: %+v", pkixName)
 
 	// TODO: figure out how long we want these to be valid for
 	// if a short time, then we want to afford them a button to regenerate certs
@@ -82,10 +78,7 @@ func RandomKeyStoreForTest() X509KeyStore {
 	}
 
 	cert, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
-	parsedCert, err := x509.ParseCertificate(cert)
-	fmt.Printf("Here is the raw issuer value off the created cert: %v", parsedCert.Issuer)
-	fmt.Printf("\n\n THE ISSUER OF THE SELF SIGNED CERT: \n\n Here is the RDN sequence for the newly minted cert: %+v\n", parsedCert.Issuer.ToRDNSequence())
-	fmt.Printf("\n\n This should say AtScale: %v \n", parsedCert.Issuer.Organization)
+	_, err = x509.ParseCertificate(cert)
 	if err != nil {
 		panic(err)
 	}

--- a/keystore.go
+++ b/keystore.go
@@ -4,6 +4,8 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
+	"crypto/x509/pkix"
+	"fmt"
 	"math/big"
 	"time"
 )
@@ -45,24 +47,45 @@ func NewMemoryX509KeyStore(privKey *rsa.PrivateKey, cert []byte) *MemoryX509KeyS
 }
 
 func RandomKeyStoreForTest() X509KeyStore {
+	fmt.Printf("generating new key store")
 	key, err := rsa.GenerateKey(rand.Reader, 1024)
 	if err != nil {
 		panic(err)
 	}
 
 	now := time.Now()
+	pkixName := pkix.Name{
+		Country:            []string{"US"},
+		Organization:       []string{"AtScale"},
+		OrganizationalUnit: []string{"Apps"},
+		Locality:           []string{"Locality1"},
+		Province:           []string{"province1"},
+		StreetAddress:      []string{"street address"},
+		PostalCode:         []string{"postal code"},
+		SerialNumber:       "customserialnumber",
+		CommonName:         "commonName",
+	}
+	fmt.Printf("\n\n pay attention! \n\nHere is the raw issuer value prior to creating cert: %v", pkixName)
+	fmt.Printf("\n\n pay attention! \n\nHere is the somewhat formatted issuer value prior to creating cert: %+v", pkixName)
 
+	// TODO: figure out how long we want these to be valid for
+	// if a short time, then we want to afford them a button to regenerate certs
 	template := &x509.Certificate{
-		SerialNumber: big.NewInt(0),
-		NotBefore:    now.Add(-5 * time.Minute),
-		NotAfter:     now.Add(365 * 24 * time.Hour),
-
+		SerialNumber:          big.NewInt(0),
+		NotBefore:             now.Add(-5 * time.Minute),
+		NotAfter:              now.Add(365 * 24 * time.Hour),
+		Issuer:                pkixName,
+		Subject:               pkixName, // this will get used as the issuer value (should solve the empty issuer dn problemn)
 		KeyUsage:              x509.KeyUsageDigitalSignature,
 		ExtKeyUsage:           []x509.ExtKeyUsage{},
 		BasicConstraintsValid: true,
 	}
 
 	cert, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	parsedCert, err := x509.ParseCertificate(cert)
+	fmt.Printf("Here is the raw issuer value off the created cert: %v", parsedCert.Issuer)
+	fmt.Printf("\n\n THE ISSUER OF THE SELF SIGNED CERT: \n\n Here is the RDN sequence for the newly minted cert: %+v\n", parsedCert.Issuer.ToRDNSequence())
+	fmt.Printf("\n\n This should say AtScale: %v \n", parsedCert.Issuer.Organization)
 	if err != nil {
 		panic(err)
 	}

--- a/keystore.go
+++ b/keystore.go
@@ -37,6 +37,13 @@ func (ks *MemoryX509KeyStore) GetKeyPair() (*rsa.PrivateKey, []byte, error) {
 	return ks.privateKey, ks.cert, nil
 }
 
+func NewMemoryX509KeyStore(privKey *rsa.PrivateKey, cert []byte) *MemoryX509KeyStore {
+	return &MemoryX509KeyStore{
+		privateKey: privKey,
+		cert:       cert,
+	}
+}
+
 func RandomKeyStoreForTest() X509KeyStore {
 	key, err := rsa.GenerateKey(rand.Reader, 1024)
 	if err != nil {

--- a/sign.go
+++ b/sign.go
@@ -10,8 +10,8 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/beevik/etree"
 	"github.com/AtScaleInc/goxmldsig/etreeutils"
+	"github.com/beevik/etree"
 )
 
 type SigningContext struct {
@@ -165,8 +165,18 @@ func (ctx *SigningContext) ConstructSignature(el *etree.Element, enveloped bool)
 	if err != nil {
 		return nil, err
 	}
-
+	// get string representation of the detached sign info
+	// first have to get a pointer to a document
+	docContainingSignedInfo := &etree.Document{Element: *detatchedSignedInfo}
+	stringRep, err := docContainingSignedInfo.WriteToString()
+	if err != nil {
+		fmt.Printf("Failed to write to string:\n%v\n", err)
+	}
+	fmt.Printf("The detachedSignedInfo(the thing to be digested): \n%v\n", stringRep)
 	digest, err := ctx.digest(detatchedSignedInfo)
+	fmt.Printf("The digest produced using %v is:\n%v\n", ctx.Hash, digest)
+
+	fmt.Printf("")
 	if err != nil {
 		return nil, err
 	}

--- a/sign.go
+++ b/sign.go
@@ -24,11 +24,12 @@ type SigningContext struct {
 
 func NewDefaultSigningContext(ks X509KeyStore) *SigningContext {
 	return &SigningContext{
-		Hash:          crypto.SHA256,
-		KeyStore:      ks,
-		IdAttribute:   DefaultIdAttr,
-		Prefix:        DefaultPrefix,
-		Canonicalizer: MakeC14N11Canonicalizer(),
+		Hash:        crypto.SHA256,
+		KeyStore:    ks,
+		IdAttribute: DefaultIdAttr,
+		Prefix:      DefaultPrefix,
+		// Canonicalizer: MakeC14N11Canonicalizer(), does NOT work with netiq
+		Canonicalizer: MakeC14N10ExclusiveCanonicalizerWithPrefixList(""), // does work with net iq
 	}
 }
 
@@ -43,6 +44,7 @@ func (ctx *SigningContext) SetSignatureMethod(algorithmID string) error {
 	return nil
 }
 
+// digest request before adding in signed info
 func (ctx *SigningContext) digest(el *etree.Element) ([]byte, error) {
 	canonical, err := ctx.Canonicalizer.Canonicalize(el)
 	if err != nil {
@@ -58,6 +60,7 @@ func (ctx *SigningContext) digest(el *etree.Element) ([]byte, error) {
 	return hash.Sum(nil), nil
 }
 
+// el here is auth request
 func (ctx *SigningContext) constructSignedInfo(el *etree.Element, enveloped bool) (*etree.Element, error) {
 	digestAlgorithmIdentifier := ctx.GetDigestAlgorithmIdentifier()
 	if digestAlgorithmIdentifier == "" {
@@ -161,6 +164,7 @@ func (ctx *SigningContext) ConstructSignature(el *etree.Element, enveloped bool)
 
 	// Finally detatch the SignedInfo in order to capture all of the namespace
 	// declarations in the scope we've constructed.
+	// what is the significance of capturing namespaces?
 	detatchedSignedInfo, err := etreeutils.NSDetatch(sigNSCtx, signedInfo)
 	if err != nil {
 		return nil, err
@@ -172,8 +176,9 @@ func (ctx *SigningContext) ConstructSignature(el *etree.Element, enveloped bool)
 	if err != nil {
 		fmt.Printf("Failed to write to string:\n%v\n", err)
 	}
-	fmt.Printf("The detachedSignedInfo(the thing to be digested): \n%v\n", stringRep)
-	digest, err := ctx.digest(detatchedSignedInfo)
+
+	digest, err := ctx.digest(detatchedSignedInfo) // original line -- detached signed info at this point had namespaces added by the nsdetach function
+	// digest, err := ctx.digest(signedInfo.Copy()) // failed attempt - thought by preventing adding attributes to the signed info element it would yield a valid signature
 	fmt.Printf("The digest produced using %v is:\n%v\n", ctx.Hash, digest)
 
 	fmt.Printf("")

--- a/sign.go
+++ b/sign.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 
 	"github.com/beevik/etree"
-	"github.com/russellhaering/goxmldsig/etreeutils"
+	"github.com/AtScaleInc/goxmldsig/etreeutils"
 )
 
 type SigningContext struct {

--- a/sign.go
+++ b/sign.go
@@ -172,9 +172,7 @@ func (ctx *SigningContext) ConstructSignature(el *etree.Element, enveloped bool)
 
 	digest, err := ctx.digest(detatchedSignedInfo) // original line -- detached signed info at this point had namespaces added by the nsdetach function
 	// digest, err := ctx.digest(signedInfo.Copy()) // failed attempt - thought by preventing adding attributes to the signed info element it would yield a valid signature
-	fmt.Printf("The digest produced using %v is:\n%v\n", ctx.Hash, digest)
 
-	fmt.Printf("")
 	if err != nil {
 		return nil, err
 	}

--- a/sign.go
+++ b/sign.go
@@ -169,13 +169,6 @@ func (ctx *SigningContext) ConstructSignature(el *etree.Element, enveloped bool)
 	if err != nil {
 		return nil, err
 	}
-	// get string representation of the detached sign info
-	// first have to get a pointer to a document
-	docContainingSignedInfo := &etree.Document{Element: *detatchedSignedInfo}
-	stringRep, err := docContainingSignedInfo.WriteToString()
-	if err != nil {
-		fmt.Printf("Failed to write to string:\n%v\n", err)
-	}
 
 	digest, err := ctx.digest(detatchedSignedInfo) // original line -- detached signed info at this point had namespaces added by the nsdetach function
 	// digest, err := ctx.digest(signedInfo.Copy()) // failed attempt - thought by preventing adding attributes to the signed info element it would yield a valid signature

--- a/validate.go
+++ b/validate.go
@@ -10,8 +10,8 @@ import (
 	"regexp"
 
 	"github.com/beevik/etree"
-	"github.com/russellhaering/goxmldsig/etreeutils"
-	"github.com/russellhaering/goxmldsig/types"
+	"github.com/AtScaleInc/goxmldsig/etreeutils"
+	"github.com/AtScaleInc/goxmldsig/types"
 )
 
 var uriRegexp = regexp.MustCompile("^#[a-zA-Z_][\\w.-]*$")


### PR DESCRIPTION
Mainly updates the import statements to reflect the fact that `WE ARE THE REPO NOW`.  There's also the key change in `sign.go` which changes the canonicalizer used in the default signing context to `C14N10ExclusiveCanonicalizerWithPrefixList`. Though the W3 spec says that applications wanting maximal interoperability should implement the original canonicalizer, it seems that those fast and loose hooligans over at micro focus have opted to skirt this prescription by the spec. 